### PR TITLE
fixed: Http 헤더 추가

### DIFF
--- a/sogong_spring/demoSignaling/src/main/java/com/example/demosignaling/WebSocketHandShake.java
+++ b/sogong_spring/demoSignaling/src/main/java/com/example/demosignaling/WebSocketHandShake.java
@@ -1,0 +1,26 @@
+package com.example.demosignaling;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+public class WebSocketHandShake implements HandshakeInterceptor{
+        @Override
+        public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+            HttpHeaders headers = request.getHeaders();
+            headers.add("Connection","upgrade");
+            headers.add("Upgrade", "websocket");
+            headers.add("Sec-Websocket-Version", "13");
+            headers.add("Sec-Websocket-Key", "Rk84UEVDMjIxREVDMDhGMzY0M0M3OUY5");
+            return true;
+        }
+
+        @Override
+        public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+
+        }
+    }


### PR DESCRIPTION
일부 클라이언트의 경우 http 헤더에 connection-upgrade가 적용되지 않음
handshake 과정을 통해 http 프로토콜에서 websocket 프로토콜로 넘어가는데 이 과정을 수기로 진행